### PR TITLE
fix(ui): add CrossOver font fallback for IMGUI overlays

### DIFF
--- a/DpsMeter/BoxOpenOverlayBehaviour.cs
+++ b/DpsMeter/BoxOpenOverlayBehaviour.cs
@@ -124,6 +124,7 @@ namespace TbhDpsMeter
             _cell = new GUIStyle { fontSize = Mathf.Max(9, fsm - 1), richText = true, alignment = TextAnchor.MiddleRight }; _cell.normal.textColor = Color.white;
             _btn = new GUIStyle(GUI.skin.button) { fontSize = fsm, fontStyle = FontStyle.Bold, richText = true };
             _box = new GUIStyle(); _box.normal.background = _bgTex;
+            OverlayFonts.Apply(_title, _label, _dim, _tiny, _col, _cell, _btn);
             _stylesReady = true;
         }
 

--- a/DpsMeter/BoxOverlayBehaviour.cs
+++ b/DpsMeter/BoxOverlayBehaviour.cs
@@ -137,6 +137,7 @@ namespace TbhDpsMeter
             _col = new GUIStyle { fontSize = fs, richText = true, alignment = TextAnchor.MiddleRight }; _col.normal.textColor = Color.white;
             _btn = new GUIStyle(GUI.skin.button) { fontSize = fsm, fontStyle = FontStyle.Bold, richText = true };
             _box = new GUIStyle(); _box.normal.background = _bgTex;
+            OverlayFonts.Apply(_title, _label, _dim, _tiny, _col, _btn);
             _stylesReady = true;
         }
 

--- a/DpsMeter/CompareOverlayBehaviour.cs
+++ b/DpsMeter/CompareOverlayBehaviour.cs
@@ -259,8 +259,9 @@ namespace TbhDpsMeter
             _tiny.normal.textColor = new Color(0.7f, 0.75f, 0.85f);
             _col = new GUIStyle { fontSize = fs, richText = true };
             _col.normal.textColor = Color.white;
-            _btn = new GUIStyle(GUI.skin.button) { fontSize = fsm, fontStyle = FontStyle.Bold };
+            _btn = new GUIStyle(GUI.skin.button) { fontSize = fsm, fontStyle = FontStyle.Bold, richText = true };
             _box = new GUIStyle(); _box.normal.background = _bgTex;
+            OverlayFonts.Apply(_title, _label, _dim, _tiny, _col, _btn);
             _stylesReady = true;
         }
 

--- a/DpsMeter/FarmOverlayBehaviour.cs
+++ b/DpsMeter/FarmOverlayBehaviour.cs
@@ -202,8 +202,9 @@ namespace TbhDpsMeter
             _tiny.normal.textColor = new Color(0.7f, 0.75f, 0.85f);
             _col = new GUIStyle { fontSize = fs, richText = true, alignment = TextAnchor.MiddleRight };
             _col.normal.textColor = Color.white;
-            _btn = new GUIStyle(GUI.skin.button) { fontSize = fsm, fontStyle = FontStyle.Bold };
+            _btn = new GUIStyle(GUI.skin.button) { fontSize = fsm, fontStyle = FontStyle.Bold, richText = true };
             _box = new GUIStyle(); _box.normal.background = _bgTex;
+            OverlayFonts.Apply(_title, _label, _dim, _tiny, _col, _btn);
             _stylesReady = true;
         }
 

--- a/DpsMeter/HubOverlayBehaviour.cs
+++ b/DpsMeter/HubOverlayBehaviour.cs
@@ -129,6 +129,7 @@ namespace TbhDpsMeter
             _icon = new GUIStyle { fontSize = fs + 3, richText = true, alignment = TextAnchor.MiddleCenter }; _icon.normal.textColor = Color.white;
             _tip = new GUIStyle { fontSize = fsm, richText = true, alignment = TextAnchor.MiddleCenter }; _tip.normal.textColor = new Color(0.95f, 0.95f, 0.95f);
             _box = new GUIStyle(); _box.normal.background = _bgTex;
+            OverlayFonts.Apply(_title, _label, _dim, _tiny, _tagR, _btn, _icon, _tip);
             _stylesReady = true;
         }
 

--- a/DpsMeter/LootMapOverlayBehaviour.cs
+++ b/DpsMeter/LootMapOverlayBehaviour.cs
@@ -114,6 +114,7 @@ namespace TbhDpsMeter
             _tip = new GUIStyle { fontSize = fsm, richText = true, alignment = TextAnchor.MiddleCenter }; _tip.normal.textColor = new Color(0.95f, 0.95f, 0.95f);
             _tipMulti = new GUIStyle { fontSize = fsm, richText = true, wordWrap = false, alignment = TextAnchor.UpperLeft }; _tipMulti.normal.textColor = new Color(0.95f, 0.95f, 0.95f);
             _box = new GUIStyle(); _box.normal.background = _bgTex;
+            OverlayFonts.Apply(_title, _label, _dim, _tiny, _btn, _tip, _tipMulti);
             _stylesReady = true;
         }
 

--- a/DpsMeter/OverlayBehaviour.cs
+++ b/DpsMeter/OverlayBehaviour.cs
@@ -405,17 +405,18 @@ namespace TbhDpsMeter
             _builtFs = fs; _builtFsm = fsm;
             _title = new GUIStyle { fontSize = fs, fontStyle = FontStyle.Bold, richText = true };
             _title.normal.textColor = new Color(1f, 0.86f, 0.35f);
-            _big = new GUIStyle { fontSize = fs + 9, fontStyle = FontStyle.Bold };
+            _big = new GUIStyle { fontSize = fs + 9, fontStyle = FontStyle.Bold, richText = true };
             _big.normal.textColor = Color.white;
-            _label = new GUIStyle { fontSize = fs };
+            _label = new GUIStyle { fontSize = fs, richText = true };
             _label.normal.textColor = new Color(0.93f, 0.93f, 0.93f);
-            _dim = new GUIStyle { fontSize = fsm };
+            _dim = new GUIStyle { fontSize = fsm, richText = true };
             _dim.normal.textColor = new Color(0.78f, 0.84f, 0.95f);
-            _tiny = new GUIStyle { fontSize = Mathf.Max(9, fsm - 2) };
+            _tiny = new GUIStyle { fontSize = Mathf.Max(9, fsm - 2), richText = true };
             _tiny.normal.textColor = new Color(0.7f, 0.75f, 0.85f);
-            _btn = new GUIStyle(GUI.skin.button) { fontSize = fsm, fontStyle = FontStyle.Bold };
+            _btn = new GUIStyle(GUI.skin.button) { fontSize = fsm, fontStyle = FontStyle.Bold, richText = true };
             _box = new GUIStyle();
             _box.normal.background = _bgTex;
+            OverlayFonts.Apply(_title, _big, _label, _dim, _tiny, _btn);
             _stylesReady = true;
         }
 

--- a/DpsMeter/OverlayFonts.cs
+++ b/DpsMeter/OverlayFonts.cs
@@ -1,0 +1,270 @@
+using System;
+using System.Collections.Generic;
+using System.IO;
+using BepInEx;
+using BepInEx.Logging;
+using UnityEngine;
+
+namespace TbhDpsMeter
+{
+    /// <summary>Shared font resolver for IMGUI overlays. CrossOver/Wine bottles can have an empty or
+    /// stale system-font registry, so the overlays should not depend solely on Unity's default font.</summary>
+    internal static class OverlayFonts
+    {
+        private const int ProbeSize = 16;
+        private const string Auto = "Auto";
+
+        private static readonly string[] AutoFamilies =
+        {
+            "Source Han Sans TC",
+            "Source Han Sans",
+            "Microsoft JhengHei UI",
+            "Microsoft JhengHei",
+            "Microsoft YaHei UI",
+            "Microsoft YaHei",
+            "SimSun",
+            "Arial Unicode MS",
+            "Segoe UI",
+            "Arial",
+        };
+
+        private static readonly string[] PreferredFiles =
+        {
+            "SourceHanSansTC-Regular.otf",
+            "SourceHanSansTC-Normal.otf",
+            "SourceHanSans-Regular.otf",
+            "SourceHanSans-Normal.otf",
+            "msjh.ttc",
+            "msyh.ttc",
+            "simsun.ttc",
+            "arialuni.ttf",
+            "segoeui.ttf",
+            "arial.ttf",
+        };
+
+        private static ManualLogSource _log;
+        private static Font _activeFont;
+        private static bool _loggedDefault;
+
+        public static Font ActiveFont => _activeFont;
+
+        public static void Init(string configuredFamily, string configuredPath, ManualLogSource log)
+        {
+            _log = log;
+            _activeFont = null;
+            _loggedDefault = false;
+
+            try
+            {
+                if (TryConfiguredPath(configuredPath, out _activeFont)) return;
+                if (TryConfiguredFamily(configuredFamily, out _activeFont)) return;
+                if (TryAutoFamilies(out _activeFont)) return;
+                if (TryFontDirectories(out _activeFont)) return;
+
+                LogDefault("No overlay font fallback resolved; using Unity default. If CrossOver text is invisible, install Asian Fonts Component or set UI.FontPath to a .ttf/.otf/.ttc file.");
+            }
+            catch (Exception ex)
+            {
+                _activeFont = null;
+                LogWarning("Overlay font resolver failed; using Unity default. " + ex.Message);
+            }
+        }
+
+        public static void Apply(params GUIStyle[] styles)
+        {
+            if (_activeFont == null) return;
+            try { if (GUI.skin != null) GUI.skin.font = _activeFont; } catch { }
+            if (styles == null) return;
+            for (int i = 0; i < styles.Length; i++)
+            {
+                try { if (styles[i] != null) styles[i].font = _activeFont; } catch { }
+            }
+        }
+
+        private static bool TryConfiguredPath(string configuredPath, out Font font)
+        {
+            font = null;
+            string path = Normalize(configuredPath);
+            if (string.IsNullOrEmpty(path)) return false;
+
+            foreach (string candidate in ConfiguredPathCandidates(path))
+            {
+                if (TryFontFile(candidate, "configured path", out font)) return true;
+            }
+
+            LogWarning("UI.FontPath was set but no readable font file was found: " + path);
+            return false;
+        }
+
+        private static bool TryConfiguredFamily(string configuredFamily, out Font font)
+        {
+            font = null;
+            string family = Normalize(configuredFamily);
+            if (string.IsNullOrEmpty(family) || Same(family, Auto)) return false;
+
+            string matched = MatchInstalledFamily(family);
+            if (TryOsFont(string.IsNullOrEmpty(matched) ? family : matched, "configured family", out font)) return true;
+
+            LogWarning("UI.FontFamily was set but Unity could not load it: " + family);
+            return false;
+        }
+
+        private static bool TryAutoFamilies(out Font font)
+        {
+            font = null;
+            for (int i = 0; i < AutoFamilies.Length; i++)
+            {
+                string matched = MatchInstalledFamily(AutoFamilies[i]);
+                if (string.IsNullOrEmpty(matched)) continue;
+                if (TryOsFont(matched, "installed family", out font)) return true;
+            }
+            return false;
+        }
+
+        private static bool TryFontDirectories(out Font font)
+        {
+            font = null;
+            var dirs = new List<string>();
+            try { dirs.Add(Path.Combine(Paths.PluginPath, "fonts")); } catch { }
+            dirs.Add(@"C:\windows\Fonts");
+
+            for (int i = 0; i < dirs.Count; i++)
+            {
+                if (TryPreferredFontFile(dirs[i], out font)) return true;
+            }
+            return false;
+        }
+
+        private static bool TryPreferredFontFile(string dir, out Font font)
+        {
+            font = null;
+            if (string.IsNullOrEmpty(dir) || !Directory.Exists(dir)) return false;
+
+            for (int i = 0; i < PreferredFiles.Length; i++)
+            {
+                string path = Path.Combine(dir, PreferredFiles[i]);
+                if (TryFontFile(path, "font file", out font)) return true;
+            }
+
+            try
+            {
+                foreach (string path in Directory.GetFiles(dir))
+                {
+                    if (IsFontFile(path) && TryFontFile(path, "font file", out font)) return true;
+                }
+            }
+            catch { }
+            return false;
+        }
+
+        private static bool TryOsFont(string family, string source, out Font font)
+        {
+            font = null;
+            if (string.IsNullOrEmpty(family)) return false;
+            try
+            {
+                font = Font.CreateDynamicFontFromOSFont(family, ProbeSize);
+                if (font == null) return false;
+                LogInfo("Overlay font resolved from " + source + ": " + family);
+                return true;
+            }
+            catch
+            {
+                font = null;
+                return false;
+            }
+        }
+
+        private static bool TryFontFile(string path, string source, out Font font)
+        {
+            font = null;
+            if (string.IsNullOrEmpty(path) || !File.Exists(path) || !IsFontFile(path)) return false;
+            try
+            {
+                font = new Font(path);
+                if (font == null) return false;
+                LogInfo("Overlay font resolved from " + source + ": " + path);
+                return true;
+            }
+            catch
+            {
+                font = null;
+                return false;
+            }
+        }
+
+        private static string MatchInstalledFamily(string requested)
+        {
+            if (string.IsNullOrEmpty(requested)) return null;
+            string[] names = InstalledFontNames();
+            for (int i = 0; i < names.Length; i++) if (Same(names[i], requested)) return names[i];
+            for (int i = 0; i < names.Length; i++) if (StartsWith(names[i], requested)) return names[i];
+            for (int i = 0; i < names.Length; i++) if (Contains(names[i], requested)) return names[i];
+            return null;
+        }
+
+        private static string[] InstalledFontNames()
+        {
+            var result = new List<string>();
+            try
+            {
+                var names = Font.GetOSInstalledFontNames();
+                if (names != null)
+                {
+                    foreach (string raw in names)
+                    {
+                        string name = Normalize(raw);
+                        if (!string.IsNullOrEmpty(name) && !ContainsExact(result, name)) result.Add(name);
+                    }
+                }
+            }
+            catch { }
+            return result.ToArray();
+        }
+
+        private static IEnumerable<string> ConfiguredPathCandidates(string path)
+        {
+            yield return path;
+            if (Path.IsPathRooted(path)) yield break;
+
+            string pluginPath = null;
+            try { pluginPath = Paths.PluginPath; } catch { }
+            if (string.IsNullOrEmpty(pluginPath)) yield break;
+
+            yield return Path.Combine(pluginPath, path);
+            yield return Path.Combine(pluginPath, "fonts", path);
+        }
+
+        private static bool IsFontFile(string path)
+        {
+            return path.EndsWith(".ttf", StringComparison.OrdinalIgnoreCase)
+                || path.EndsWith(".otf", StringComparison.OrdinalIgnoreCase)
+                || path.EndsWith(".ttc", StringComparison.OrdinalIgnoreCase);
+        }
+
+        private static string Normalize(string value)
+        {
+            return string.IsNullOrEmpty(value) ? "" : value.Trim().Trim('"');
+        }
+
+        private static bool Same(string a, string b) => string.Equals(a, b, StringComparison.OrdinalIgnoreCase);
+        private static bool StartsWith(string a, string b) => a != null && b != null && a.StartsWith(b, StringComparison.OrdinalIgnoreCase);
+        private static bool Contains(string a, string b) => a != null && b != null && a.IndexOf(b, StringComparison.OrdinalIgnoreCase) >= 0;
+
+        private static bool ContainsExact(List<string> values, string value)
+        {
+            for (int i = 0; i < values.Count; i++) if (Same(values[i], value)) return true;
+            return false;
+        }
+
+        private static void LogInfo(string message) { try { _log?.LogInfo(message); } catch { } }
+        private static void LogWarning(string message) { try { _log?.LogWarning(message); } catch { } }
+
+        private static void LogDefault(string message)
+        {
+            if (_loggedDefault) return;
+            _loggedDefault = true;
+            LogWarning(message);
+        }
+    }
+}

--- a/DpsMeter/Plugin.cs
+++ b/DpsMeter/Plugin.cs
@@ -31,6 +31,8 @@ namespace TbhDpsMeter
         public static ConfigEntry<bool> StartVisible;
         public static ConfigEntry<int> FontSize;        // primary/large text (titles, main numbers, list rows)
         public static ConfigEntry<int> FontSizeSmall;   // secondary/detail text (dim hints, axis labels, buttons)
+        public static ConfigEntry<string> FontFamily;   // optional IMGUI font family fallback (Auto = resolver list)
+        public static ConfigEntry<string> FontPath;     // optional IMGUI font file path (.ttf/.otf/.ttc)
         public static ConfigEntry<float> UIScale;
         public static ConfigEntry<bool> HideOnGameMenu;
         public static ConfigEntry<bool> BorderOn;        // panel border, toggled from the F1 control center
@@ -125,6 +127,9 @@ namespace TbhDpsMeter
             StartVisible = Config.Bind("UI", "StartVisible", true, "Show the overlay on launch.");
             FontSize = Config.Bind("UI", "FontSize", 15, "Primary/large font size: titles, main numbers, list rows. Adjust live from the F1 control center.");
             FontSizeSmall = Config.Bind("UI", "FontSizeSmall", 13, "Secondary/detail font size: dim hints, chart axis labels, buttons. Adjust live from the F1 control center.");
+            FontFamily = Config.Bind("UI", "FontFamily", "Auto", "Overlay font family. Auto tries CJK-capable fonts first; set to a specific installed family if needed.");
+            FontPath = Config.Bind("UI", "FontPath", "", "Optional overlay font file path (.ttf/.otf/.ttc). Relative paths are resolved under BepInEx/plugins and BepInEx/plugins/fonts.");
+            OverlayFonts.Init(FontFamily.Value, FontPath.Value, Logger);
             UIScale = Config.Bind("UI", "UIScale", 1.0f, "Global overlay scale (0.6–1.5). Panels auto-shrink further if they'd exceed the screen. Adjust live with Ctrl+PageUp/PageDown or the F1 control center's −/+ control.");
             HideOnGameMenu = Config.Bind("UI", "HideOnGameMenu", true, "Hide all overlays while a game menu (TAB) is open. Toggle live from the F1 control center.");
             BorderOn = Config.Bind("UI", "PanelBorder", false, "Draw a border around every overlay panel. Toggle live from the F1 control center.");

--- a/DpsMeter/PricePeekBehaviour.cs
+++ b/DpsMeter/PricePeekBehaviour.cs
@@ -97,6 +97,7 @@ namespace TbhDpsMeter
             _tiny = new GUIStyle { fontSize = Mathf.Max(9, fsm - 2), richText = true }; _tiny.normal.textColor = new Color(0.62f, 0.68f, 0.78f);
             _tinyR = new GUIStyle(_tiny) { alignment = TextAnchor.UpperRight };   // right-aligned qty in the order book
             _box = new GUIStyle(); _box.normal.background = _bgTex;
+            OverlayFonts.Apply(_title, _label, _dim, _tiny, _tinyR);
             _stylesReady = true;
         }
 

--- a/DpsMeter/TakenOverlayBehaviour.cs
+++ b/DpsMeter/TakenOverlayBehaviour.cs
@@ -214,17 +214,18 @@ namespace TbhDpsMeter
             _builtFs = fs; _builtFsm = fsm;
             _title = new GUIStyle { fontSize = fs, fontStyle = FontStyle.Bold, richText = true };
             _title.normal.textColor = new Color(1f, 0.55f, 0.45f);
-            _big = new GUIStyle { fontSize = fs + 9, fontStyle = FontStyle.Bold };
+            _big = new GUIStyle { fontSize = fs + 9, fontStyle = FontStyle.Bold, richText = true };
             _big.normal.textColor = Color.white;
-            _label = new GUIStyle { fontSize = fs };
+            _label = new GUIStyle { fontSize = fs, richText = true };
             _label.normal.textColor = new Color(0.93f, 0.93f, 0.93f);
-            _dim = new GUIStyle { fontSize = fsm };
+            _dim = new GUIStyle { fontSize = fsm, richText = true };
             _dim.normal.textColor = new Color(0.95f, 0.84f, 0.78f);
-            _tiny = new GUIStyle { fontSize = Mathf.Max(9, fsm - 2) };
+            _tiny = new GUIStyle { fontSize = Mathf.Max(9, fsm - 2), richText = true };
             _tiny.normal.textColor = new Color(0.85f, 0.75f, 0.7f);
-            _btn = new GUIStyle(GUI.skin.button) { fontSize = fsm, fontStyle = FontStyle.Bold };
+            _btn = new GUIStyle(GUI.skin.button) { fontSize = fsm, fontStyle = FontStyle.Bold, richText = true };
             _box = new GUIStyle();
             _box.normal.background = _bgTex;
+            OverlayFonts.Apply(_title, _big, _label, _dim, _tiny, _btn);
             _stylesReady = true;
         }
 

--- a/README.md
+++ b/README.md
@@ -186,7 +186,14 @@ File: `<game folder>\BepInEx\config\tbh.dpsmeter.cfg` (created after the first r
 ```
 [General]
 Language = Auto   # force a language: zh-Hant / zh-Hans / en / ja / es
+
+[UI]
+FontFamily = Auto # overlay font fallback; Auto tries CJK-capable fonts first
+FontPath =        # optional .ttf/.otf/.ttc path, e.g. C:\windows\Fonts\SourceHanSansTC-Regular.otf
 ```
+
+### CrossOver font troubleshooting
+On macOS/CrossOver, if overlay panels and charts render but all text is invisible, install **Asian Fonts Component** into the same bottle as Steam/TBH, then fully stop and restart that bottle. If text is still missing, set `UI.FontPath` to a CJK-capable font file such as `C:\windows\Fonts\SourceHanSansTC-Regular.otf`, or place a font under `<game>\BepInEx\plugins\fonts\` and point `UI.FontPath` at it.
 
 ## Uninstall
 Delete from the game folder: `winhttp.dll`, `doorstop_config.ini`, `.doorstop_version`,

--- a/README.zh-Hant.md
+++ b/README.zh-Hant.md
@@ -170,7 +170,14 @@
 ```
 [General]
 Language = Auto   # 可改成 zh-Hant / zh-Hans / en / ja / es 強制語言
+
+[UI]
+FontFamily = Auto # 疊加面板字型 fallback；Auto 會優先嘗試 CJK 字型
+FontPath =        # 可指定 .ttf/.otf/.ttc，例如 C:\windows\Fonts\SourceHanSansTC-Regular.otf
 ```
+
+### CrossOver 字型疑難排解
+macOS/CrossOver 下如果面板和圖表有出現、但文字全部不可見，請把 **Asian Fonts Component** 安裝到執行 Steam/TBH 的同一個 bottle，然後完整停止並重啟該 bottle。若重啟後仍無字，可將 `UI.FontPath` 指到 CJK 字型檔，例如 `C:\windows\Fonts\SourceHanSansTC-Regular.otf`，或把字型放到 `<遊戲>\BepInEx\plugins\fonts\` 後指定該路徑。
 
 ## 移除
 刪掉遊戲資料夾裡的：`winhttp.dll`、`doorstop_config.ini`、`.doorstop_version`、


### PR DESCRIPTION
## Summary

Fixes #1.

This adds a shared IMGUI overlay font fallback resolver so CrossOver/Wine users are not dependent on Unity's default font resolution when the bottle has missing or stale system font registry state.

## Changes

- Add `OverlayFonts` to resolve a usable overlay font from:
  - `UI.FontPath`
  - `UI.FontFamily`
  - installed OS font names
  - `BepInEx/plugins/fonts`
  - `C:\windows\Fonts`
  - Unity default as final fallback
- Add `UI.FontFamily = Auto` and `UI.FontPath = ""` config entries.
- Apply the resolved font to all overlay `GUIStyle` instances and `GUI.skin.font`.
- Enable `richText` consistently for DPS/taken overlay styles that render `<color>` / `<size>` text.
- Document minimal CrossOver font troubleshooting in English and Traditional Chinese READMEs.

## Validation

- `dotnet run --project TrackerTests/TrackerTests.csproj` passed.
- `dotnet build DpsMeter/DpsMeter.csproj -c Release /p:GameDir=<CrossOver TaskbarHero path>` passed with 0 warnings and 0 errors.

Manual CrossOver restart validation is still recommended to confirm the selected font appears in the BepInEx log and overlay text renders in-game.